### PR TITLE
fix for builder > 3.0.1

### DIFF
--- a/lib/rack_session_access/middleware.rb
+++ b/lib/rack_session_access/middleware.rb
@@ -65,7 +65,7 @@ module RackSessionAccess
           :enctype => 'application/x-www-form-urlencoded'
         }) do |xml|
           xml.input(:type => 'hidden', :name =>'_method', :value => 'put')
-          xml.textarea("", :cols => 40, :rows => 10, :name => 'data')
+          xml.textarea(:cols => 40, :rows => 10, :name => 'data') {}
           xml.p do |xml|
             xml.input(:type => 'submit', :value => "Update")
           end


### PR DESCRIPTION
new builder does not accept empty strings to create an empty tag.
It will automatically turn it into a self closing tag.
