### PR TITLE
Fixed session to xml inspector for Rails4 ActionDispatch Session.

### DIFF
--- a/lib/rack_session_access/middleware.rb
+++ b/lib/rack_session_access/middleware.rb
@@ -51,7 +51,12 @@ module RackSessionAccess
         render do |xml|
           xml.h2 "Rack session data"
           xml.ul do |xml|
-            request.env[@key].each do |k,v|
+            session = request.env[@key]
+            if session.respond_to?(:to_hash)
+              # session is ActionDispatch::Request::Session
+              session = session.to_hash
+            end
+            session.each do |k,v|
               xml.li("#{k.inspect} : #{v.inspect}")
             end
           end


### PR DESCRIPTION
ActionDispatch 4.0.0(beta1) Request::Session don't have `each` method.

```
undefined method `each' for #<ActionDispatch::Request::Session:0x007ff5ef980110>
 # /Users/yuichi-tateno/git/github/rack_session_access/lib/rack_session_access/middleware.rb:54:in `block (2 levels) in show'
```
