### PR TITLE
correct usage of devise integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ end
 ```ruby
 module FeatureHelpers
   def logged_as(user)
-    page.set_rack_session('warden.user.user.key' => User.serialize_into_session(user).unshift("User"))
+    page.set_rack_session('warden.user.user.key' => User.serialize_into_session(user))
   end
 end
 ```


### PR DESCRIPTION
I needed to remove the `.unshift("User")` when I serialize my user object into the session... 

looks like devise changed how this works (way back in 2011?? https://github.com/plataformatec/devise/commit/7396c6911d5daef5a202af854dbe208aa7d57bce)
