### PR TITLE
Process HEAD requests as GET

### DIFF
--- a/lib/rack_session_access/middleware.rb
+++ b/lib/rack_session_access/middleware.rb
@@ -111,6 +111,7 @@ module RackSessionAccess
 
     # Return HTTP method, detect emulated method with _method param
     def request_method(request)
+      return 'GET'                            if request.head?
       return request.request_method           if request.request_method != 'POST'
       return request.params['_method'].upcase if request.params['_method']
       request.request_method


### PR DESCRIPTION
When I'm using remote browser (such as Browserstuck) my tests are failed with the following message:

```
#<ActionController::RoutingError: No route matches [HEAD] "/rack_session/edit">
```

Rails had the same issue with HEAD requests and it was fixed here: https://github.com/rails/rails/pull/19431 . So, they just process HEAD requests as GET.

P.S. I really don't know how to cover this case with RSpec and I would appreciate if you give me an advice.